### PR TITLE
added initOptions parameters for echarts.init

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-4": {
-            "ArashDalir\\EchartsPHP\\": "src/"
+            "Hisune\\EchartsPHP\\": "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,27 @@
 {
-    "name": "hisune/echarts-php",
+    "name": "arashdalir/echarts-php",
     "type": "library",
-    "description": "A php wrapper for echarts javascript libraries",
+    "description": "A php wrapper for echarts javascript libraries - forked from Hisune to extend the wrapper",
     "keywords": ["echarts", "php", "charts", "javascript"],
-    "homepage": "http://hisune.com",
     "license": "MIT",
     "authors": [
         {
-            "name": "Hisune",
-            "email": "hi@hisune.com",
-            "homepage": "http://hisune.com",
+            "name": "Arash Dalir",
+            "email": "arash.dalir+github@gmail.com",
             "role": "Developer"
         }
     ],
     "support": {
-        "email": "hi@hisune.com",
-        "issues": "https://github.com/hisune/Echarts-PHP/issues",
-        "source": "https://github.com/hisune/Echarts-PHP"
+        "email": "arash.dalir+github@gmail.com",
+        "issues": "https://github.com/arashdalir/Echarts-PHP/issues",
+        "source": "https://github.com/arashdalir/Echarts-PHP"
     },
     "require": {
         "php": ">=5.3.0"
     },
     "autoload": {
         "psr-4": {
-            "Hisune\\EchartsPHP\\": "src/"
+            "ArashDalir\\EchartsPHP\\": "src/"
         }
     }
 }

--- a/demo/line.php
+++ b/demo/line.php
@@ -43,7 +43,9 @@ function chartLine($xAxisData, $seriesData, $title = '')
     $chart->addXAxis($xAxis);
     $chart->addYAxis($yAxis);
 
-    return $chart->render(uniqid(), null, null, 'svg');
+    $chart->initOptions->renderer = 'svg';
+    $chart->initOptions->width = '800px';
+    return $chart->render(uniqid(), null, null);
 }
 
 echo chartLine(

--- a/demo/line.php
+++ b/demo/line.php
@@ -43,7 +43,7 @@ function chartLine($xAxisData, $seriesData, $title = '')
     $chart->addXAxis($xAxis);
     $chart->addYAxis($yAxis);
 
-    return $chart->render(uniqid());
+    return $chart->render(uniqid(), null, null, 'svg');
 }
 
 echo chartLine(

--- a/demo/line.php
+++ b/demo/line.php
@@ -45,7 +45,7 @@ function chartLine($xAxisData, $seriesData, $title = '')
 
     $chart->initOptions->renderer = 'svg';
     $chart->initOptions->width = '800px';
-    return $chart->render(uniqid(), null, null);
+    return $chart->render(uniqid());
 }
 
 echo chartLine(

--- a/src/Config.php
+++ b/src/Config.php
@@ -61,11 +61,10 @@ class Config
         return $option;
     }
 
-    public static function render($id, $option, $theme = null, array $attribute = null, array $events = null, $renderer = null)
+    public static function render($id, $option, $theme = null, array $attribute = null, array $events = null, $initOptions = null)
     {
     	$attribute = $attribute?:array();
     	$events = $events?:array();
-    	$renderer = $renderer?:'canvas';
 
         $attribute = self::_renderAttribute($attribute);
         is_null($theme) && $theme = 'null';
@@ -120,11 +119,13 @@ HTML;
                 }
             }
             $option = self::jsonEncode($option);
+            $initOptions = self::jsonEncode($initOptions);
             return <<<HTML
 <div id="$id" $attribute></div>
 $js
 <script type="text/javascript">
-    var $prefix$jsVar = echarts.init(document.getElementById('$id'), '$theme', {renderer: '{$renderer}'});
+	var initOptions = {$initOptions};
+    var $prefix$jsVar = echarts.init(document.getElementById('$id'), '$theme', initOptions);
     $prefix$jsVar.setOption($option);$eventsHtml
 </script>
 HTML;

--- a/src/Config.php
+++ b/src/Config.php
@@ -61,8 +61,12 @@ class Config
         return $option;
     }
 
-    public static function render($id, $option, $theme = null, array $attribute = array(), array $events = array())
+    public static function render($id, $option, $theme = null, array $attribute = null, array $events = null, $renderer = null)
     {
+    	$attribute = $attribute?:array();
+    	$events = $events?:array();
+    	$renderer = $renderer?:'canvas';
+
         $attribute = self::_renderAttribute($attribute);
         is_null($theme) && $theme = 'null';
 
@@ -120,7 +124,7 @@ HTML;
 <div id="$id" $attribute></div>
 $js
 <script type="text/javascript">
-    var $prefix$jsVar = echarts.init(document.getElementById('$id'), '$theme');
+    var $prefix$jsVar = echarts.init(document.getElementById('$id'), '$theme', {renderer: '{$renderer}'});
     $prefix$jsVar.setOption($option);$eventsHtml
 </script>
 HTML;

--- a/src/ECharts.php
+++ b/src/ECharts.php
@@ -138,7 +138,7 @@ namespace Hisune\EchartsPHP;
  */
 class ECharts extends Property
 {
-
+	public $initOptions;
     public $_events = [];
     protected $jsVar;
 
@@ -150,14 +150,15 @@ class ECharts extends Property
         if ($dist){
             Config::$dist = $dist;
         }
+        $this->initOptions = new InitOptions();
         $this->setJsVar();
     }
 
-    public function render($id, $attribute = null, $theme = null, $renderer = null)
+    public function render($id, $attribute = null, $theme = null)
     {
     	$attribute = $attribute?:array();
 
-        return Config::render($id, $this->getOption(), $theme, $attribute, $this->_events, $renderer);
+        return Config::render($id, $this->getOption(), $theme, $attribute, $this->_events, $this->initOptions);
     }
 
     public function getOption($render = null, $jsObject = false)
@@ -218,7 +219,6 @@ class ECharts extends Property
     {
         $this->yAxis[] = $this->getOption($yAxis->_options);
     }
-
 }
 
 

--- a/src/ECharts.php
+++ b/src/ECharts.php
@@ -153,9 +153,11 @@ class ECharts extends Property
         $this->setJsVar();
     }
 
-    public function render($id, $attribute = array(), $theme = null)
+    public function render($id, $attribute = null, $theme = null, $renderer = null)
     {
-        return Config::render($id, $this->getOption(), $theme, $attribute, $this->_events);
+    	$attribute = $attribute?:array();
+
+        return Config::render($id, $this->getOption(), $theme, $attribute, $this->_events, $renderer);
     }
 
     public function getOption($render = null, $jsObject = false)

--- a/src/InitOptions.php
+++ b/src/InitOptions.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ada
+ * Date: 21-Sep-18
+ * Time: 11:00
+ */
+
+namespace Hisune\EchartsPHP;
+
+class InitOptions{
+	public $devicePixelRatio = 'window.devicePixelRatio';
+	public $renderer = 'canvas';
+	public $width = null;
+	public $height = null;
+}

--- a/src/InitOptions.php
+++ b/src/InitOptions.php
@@ -9,7 +9,7 @@
 namespace Hisune\EchartsPHP;
 
 class InitOptions{
-	public $devicePixelRatio = 'window.devicePixelRatio';
+	public $devicePixelRatio = null;
 	public $renderer = 'canvas';
 	public $width = null;
 	public $height = null;


### PR DESCRIPTION
as of version 3.8, echarts.init supports renderer parameter as a member of 3rd parameter's object. because `Echarts-PHP` didn't support the 3rd parameter, it was not possible to properly assign this option. 
by merging my current version into `base:master`, a new data member is added to ECharts, which allows `width`, `height`, `devicePixelRatio` and `renderer` to be defined. Also `Config` class is extended to support this parameter.