### PR TITLE
resolved an issue with chart's height

### DIFF
--- a/src/ECharts.php
+++ b/src/ECharts.php
@@ -194,10 +194,7 @@ class ECharts extends Property{
 				$attribute["style"]["height"] = "400px";
 			}
 		}
-		else
-		{
-			$this->initOptions->height = null;
-		}
+
 		$attribute = self::_renderAttribute($attribute);
 
 		$theme = $this->jsonEncode($theme);

--- a/src/ECharts.php
+++ b/src/ECharts.php
@@ -178,6 +178,26 @@ class ECharts extends Property{
 		$option = $this->getOption();
 
 		$attribute = $attribute?:array();
+
+		if (
+			!$attribute["style"] ||
+			(is_array($attribute["style"] && !key_exists("height", $attribute["style"]))) ||
+			(is_string($attribute["style"]) && strpos($attribute["style"], "height:") === false)
+		)
+		{
+			if ($attribute["style"])
+			{
+				$attribute["style"][] = $attribute["style"];
+			}
+			if (!$this->initOptions->height)
+			{
+				$attribute["style"]["height"] = "400px";
+			}
+		}
+		else
+		{
+			$this->initOptions->height = null;
+		}
 		$attribute = self::_renderAttribute($attribute);
 
 		$theme = $this->jsonEncode($theme);
@@ -409,13 +429,28 @@ HTML;
 	{
 		$attributeString = '';
 
-		if(!isset($attribute['style']))
-		{
-			$attribute['style'] = 'height:400px';
-		}
 		foreach($attribute as $k => $v)
 		{
-			$attributeString .= " $k=\"".self::_h($v).'"';
+			if (is_array($v))
+			{
+				$temp = array();
+				foreach($v as $vK => $vV)
+				{
+					if (!is_numeric($vK))
+					{
+						$temp[] = "$vK:$vV";
+					}
+					else
+					{
+						$temp = $vK;
+					}
+				}
+
+				$v = join(";", $temp);
+			}
+
+			$v = self::_h($v);
+			$attributeString .= " $k=\"{$v}\"";
 		}
 
 		return $attributeString;


### PR DESCRIPTION
the hard-coded definition of `$attributes["style"] = "height:400px";` resulted in problems with `InitOptions` and readability of the code. 

with these changes, the value is only set to default if there is no `InitOptions::$height` set.